### PR TITLE
Load RColorBrewer package on app startup

### DIFF
--- a/app.R
+++ b/app.R
@@ -8,6 +8,7 @@ library(shiny)
 library(shinythemes)
 library(DT)
 library(dragulaR)
+library(RColorBrewer)
 # library(shinydashboardPlus) # https://github.com/DivadNojnarg/shinydashboardPlus
 
 


### PR DESCRIPTION
I was getting errors about not finding the `brewer.pal` function when trying to launch the app, so this PR ensures the `RColorBrewer` package is loaded on app startup.  I see lots of potential for this app so I'm eager to get to 🏗 !