### PR TITLE
Suppress missing argument error on app launch

### DIFF
--- a/M_verb_box.R
+++ b/M_verb_box.R
@@ -90,12 +90,17 @@ ft_opt_fmt <- function(input, output, session, string) {
 
 DT_fmt_style <- function(input, output, session, string) {
   
-  if (input$verb == "group_by"){
-    input$cols
-  } else {
-    NULL
-  }
+  # reactive for obtaining columns specified if verb is "group_by"
+  cols <- reactive({
+    req(input$verb)
+    if (input$verb == "group_by"){
+      input$cols
+    } else {
+      NULL
+    }
+  })
   
+  cols()
 }
 
 

--- a/app.R
+++ b/app.R
@@ -8,6 +8,7 @@ library(shiny)
 library(shinythemes)
 library(DT)
 library(dragulaR)
+library(RColorBrewer)
 # library(shinydashboardPlus) # https://github.com/DivadNojnarg/shinydashboardPlus
 
 


### PR DESCRIPTION
This PR hides the missing argument error that happens when a user has not dragged any of the dplyr elements to the pipeline column yet.  This was a simple fix by adding another `req()` call within the `DT_fmt_style()` function.  Not sure what happened with your branch that is causing a can't automatically merge message in GitHub, but if you need me to revise my PR I'm glad to do so.  I have lots of ideas for future enhancements and I'll open a separate issue to start the discussion :+1: 